### PR TITLE
switch to importing mgo from gopkg.in

### DIFF
--- a/mgotest.go
+++ b/mgotest.go
@@ -12,7 +12,7 @@ import (
 	"text/template"
 	"time"
 
-	"labix.org/v2/mgo"
+	"gopkg.in/mgo.v2"
 
 	"github.com/facebookgo/freeport"
 	"github.com/facebookgo/stack"

--- a/mgotest_test.go
+++ b/mgotest_test.go
@@ -3,7 +3,7 @@ package mgotest_test
 import (
 	"testing"
 
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2/bson"
 
 	"github.com/facebookgo/mgotest"
 )

--- a/rs.go
+++ b/rs.go
@@ -4,8 +4,8 @@ import (
 	"sync"
 	"time"
 
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 const (


### PR DESCRIPTION
Getting errors like

```
cannot use xyz (type *"labix.org/v2/mgo".Session) as type *"gopkg.in/mgo.v2".Session in argument to abc
```

since our projects use the (more canonical/encouraged I think) import "gopkg.in/mgo.v2"

Of course, if the projects you use mgotest in use the labix.org import URL, then this change will break those.
