### PR TITLE
allow for test commands

### DIFF
--- a/mgotest.go
+++ b/mgotest.go
@@ -87,7 +87,7 @@ func (s *Server) Start() {
 	}
 
 	waiter := waitout.New(mgoWaitingForConnections)
-	s.cmd = exec.Command("mongod", "--config", cf.Name())
+	s.cmd = exec.Command("mongod", "--config", cf.Name(), "--setParameter", "enableTestCommands=1")
 	s.cmd.Env = envPlusLcAll()
 	if os.Getenv("MGOTEST_VERBOSE") == "1" {
 		s.cmd.Stdout = io.MultiWriter(os.Stdout, waiter)

--- a/mgotest_test.go
+++ b/mgotest_test.go
@@ -39,3 +39,13 @@ func TestTwo(t *testing.T) {
 func TestThree(t *testing.T) {
 	test(t, 44)
 }
+
+func TestTestCommands(t *testing.T) {
+	mongo := mgotest.NewStartedServer(t)
+	defer mongo.Stop()
+	session := mongo.Session()
+	defer session.Close()
+	if err := session.DB("admin").Run(bson.M{"sleep": 1, "secs": 1}, nil); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
mongodb has a set of test commands you can run to debug various things:
http://docs.mongodb.org/manual/reference/command/nav-testing/

This change invokes `mongod` with a flag that enables use of these commands.
