### PR TITLE
add ability to pass command args to mongo boot

### DIFF
--- a/mgotest.go
+++ b/mgotest.go
@@ -155,7 +155,7 @@ func NewStartedServer(t Fatalf, args ...string) *Server {
 }
 
 // NewReplSetServer creates a new server starts it with ReplSet enabled.
-func NewReplSetServer(t Fatalf) *Server {
+func NewReplSetServer(t Fatalf, args ...string) *Server {
 	for {
 		s := &Server{
 			T:           t,
@@ -166,7 +166,7 @@ func NewReplSetServer(t Fatalf) *Server {
 		start := make(chan struct{})
 		go func() {
 			defer close(start)
-			s.Start()
+			s.Start(args...)
 		}()
 		select {
 		case <-start:


### PR DESCRIPTION
Use case is wanting to boot mongo with `--master`, this change proposes adding the ability to add boot args to server startup.

Also made the test internal, so I could test against my local changes instead of importing the base.
